### PR TITLE
feat: allow for custom telescope picker keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ require('telescope').load_extension('harpoon-core')
 Then open the marks page.
 
 ```lua
-Telescope harpoon-core marks
+require('telescope').load_extension('harpoon-core').marks.picker()
 ```
 
 Valid keymaps in Telescope are:
@@ -166,3 +166,19 @@ Valid keymaps in Telescope are:
 - `<ctrl-d>` delete the current mark
 - `<ctrl-p>` move mark up one position
 - `<ctrl-n>` move mark down one position
+
+You can override these keymaps in your configs as such:
+
+```lua
+vim.keymap.set("n", "<leader>r-", function()
+    local harpoon_core = require("telescope").extensions["harpoon-core"].marks
+    harpoon_core.picker({
+        attach_mappings = function(_, map)
+            map({ "i", "n" }, "<C-x>", harpoon_core.delete)
+            map({ "i", "n" }, "<C-S-k>", harpoon_core.move_up)
+            map({ "i", "n" }, "<C-S-j>", harpoon_core.move_down)
+            return true
+        end,
+    })
+end, { desc = "Open Harpoon-core Telescope picker with custom mappings" })
+```

--- a/lua/telescope/_extensions/marks.lua
+++ b/lua/telescope/_extensions/marks.lua
@@ -106,23 +106,30 @@ function M.get_results()
     return result
 end
 
-return function(opts)
+M.picker = function(opts)
     opts = opts or {}
-    pickers
-        .new(opts, {
-            prompt_title = 'Harpoon',
-            finder = M.generate_finder(),
-            sorter = conf.generic_sorter(opts),
-            previewer = conf.grep_previewer(opts),
-            attach_mappings = function(_, map)
-                map('i', '<c-d>', M.delete)
-                map('n', '<c-d>', M.delete)
-                map('i', '<c-p>', M.move_up)
-                map('n', '<c-p>', M.move_up)
-                map('i', '<c-n>', M.move_down)
-                map('n', '<c-n>', M.move_down)
-                return true
-            end,
-        })
-        :find()
+
+    local default_attach = function(_, map)
+        map('i', '<c-d>', M.delete)
+        map('n', '<c-d>', M.delete)
+        map('i', '<c-p>', M.move_up)
+        map('n', '<c-p>', M.move_up)
+        map('i', '<c-n>', M.move_down)
+        map('n', '<c-n>', M.move_down)
+        return true
+    end
+
+    -- If user provides attach_mappings, use only theirs
+    -- Otherwise fall back to the default
+    opts.attach_mappings = opts.attach_mappings or default_attach
+
+    require("telescope.pickers").new(opts, {
+        prompt_title = 'Harpoon',
+        finder = M.generate_finder(),
+        sorter = conf.generic_sorter(opts),
+        previewer = conf.grep_previewer(opts),
+        attach_mappings = opts.attach_mappings,
+    }):find()
 end
+
+return M


### PR DESCRIPTION
Thanks for this nice plugin. I realized I wasn't able to change the telescope picker mappings because the marks actions are not exposed. A quick workaround here is just to expose all of `marks.lua` (picker and actions). Additionally, we can allow for passing `attach_mappings` to the picker opts. This way we can attach custom mappings in the configs as such:

```lua
    vim.keymap.set("n", "<leader>r-", function()
        local harpoon_core = require("telescope").extensions["harpoon-core"].marks
        harpoon_core.picker({
            attach_mappings = function(_, map)
                map({ "i", "n" }, "<C-x>", harpoon_core.delete)
                map({ "i", "n" }, "<C-S-k>", harpoon_core.move_up)
                map({ "i", "n" }, "<C-S-j>", harpoon_core.move_down)
                return true
            end,
        })
    end, { desc = "Open Harpoon-core Telescope picker with custom mappings" })
```

